### PR TITLE
fix: convert hex-encoded tx fields to BigInt before sending to wallet

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,14 @@ import {
 } from "viem";
 import { waitForTransactionReceipt } from "viem/actions";
 
-import { api, applyChainId, isOk, renderJSON, renderMaybeParsedJSON } from "./utils/helpers.ts";
+import {
+  api,
+  applyChainId,
+  isOk,
+  renderJSON,
+  renderMaybeParsedJSON,
+  toBig,
+} from "./utils/helpers.ts";
 import type {
   ApiErr,
   ApiOk,
@@ -156,7 +163,17 @@ export function App() {
 
     try {
       const request = pendingTx.request as Record<string, unknown>;
-      const { from, input, to, ...txFields } = request;
+      const {
+        from,
+        input,
+        to,
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+        gas,
+        nonce,
+        value,
+        ...txFields
+      } = request;
 
       const hash = await walletClient.sendTransaction({
         ...txFields,
@@ -166,6 +183,14 @@ export function App() {
         ...(input ? { data: input as `0x${string}` } : {}),
         // Only include 'to' if it's not null (contract creation)
         ...(to ? { to: to as Address } : {}),
+        // Convert hex-encoded numeric fields to BigInt for viem compatibility
+        ...(maxFeePerGas ? { maxFeePerGas: toBig(maxFeePerGas as `0x${string}`) } : {}),
+        ...(maxPriorityFeePerGas
+          ? { maxPriorityFeePerGas: toBig(maxPriorityFeePerGas as `0x${string}`) }
+          : {}),
+        ...(gas ? { gas: toBig(gas as `0x${string}`) } : {}),
+        ...(nonce ? { nonce: Number(toBig(nonce as `0x${string}`)) } : {}),
+        ...(value ? { value: toBig(value as `0x${string}`) } : {}),
         chain,
       });
 


### PR DESCRIPTION
Numeric transaction fields (maxFeePerGas, maxPriorityFeePerGas, gas, nonce, value) arrive from the Foundry backend as hex-encoded strings (e.g. "0x9503ed240"). These were spread directly into viem's sendTransaction, which expects BigInt values. This caused viem to misparse the fees and reject transactions with "maxPriorityFeePerGas cannot be higher than maxFeePerGas".

Fixed by destructuring the numeric fields and converting them with the existing toBig() helper before passing to sendTransaction.

Tested on Tempo testnet — transactions that previously failed now go through successfully.