### PR TITLE
fix: handle gasPrice for legacy txs and use fromHex for nonce conversion

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import {
   renderJSON,
   renderMaybeParsedJSON,
   toBig,
+  toNonce,
 } from "./utils/helpers.ts";
 import type {
   ApiErr,
@@ -169,11 +170,26 @@ export function App() {
         to,
         maxFeePerGas,
         maxPriorityFeePerGas,
+        gasPrice,
         gas,
         nonce,
         value,
         ...txFields
       } = request;
+
+      // Convert hex-encoded numeric fields to BigInt/number for viem compatibility.
+      // gasPrice (legacy) and EIP-1559 fee fields are mutually exclusive.
+      const feeFields =
+        maxFeePerGas || maxPriorityFeePerGas
+          ? {
+              ...(maxFeePerGas ? { maxFeePerGas: toBig(maxFeePerGas as `0x${string}`) } : {}),
+              ...(maxPriorityFeePerGas
+                ? { maxPriorityFeePerGas: toBig(maxPriorityFeePerGas as `0x${string}`) }
+                : {}),
+            }
+          : {
+              ...(gasPrice ? { gasPrice: toBig(gasPrice as `0x${string}`) } : {}),
+            };
 
       const hash = await walletClient.sendTransaction({
         ...txFields,
@@ -183,13 +199,9 @@ export function App() {
         ...(input ? { data: input as `0x${string}` } : {}),
         // Only include 'to' if it's not null (contract creation)
         ...(to ? { to: to as Address } : {}),
-        // Convert hex-encoded numeric fields to BigInt for viem compatibility
-        ...(maxFeePerGas ? { maxFeePerGas: toBig(maxFeePerGas as `0x${string}`) } : {}),
-        ...(maxPriorityFeePerGas
-          ? { maxPriorityFeePerGas: toBig(maxPriorityFeePerGas as `0x${string}`) }
-          : {}),
+        ...feeFields,
         ...(gas ? { gas: toBig(gas as `0x${string}`) } : {}),
-        ...(nonce ? { nonce: Number(toBig(nonce as `0x${string}`)) } : {}),
+        ...(nonce ? { nonce: toNonce(nonce as `0x${string}`) } : {}),
         ...(value ? { value: toBig(value as `0x${string}`) } : {}),
         chain,
       });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,14 @@ import {
 } from "viem";
 import { waitForTransactionReceipt } from "viem/actions";
 
-import { api, applyChainId, isOk, renderJSON, renderMaybeParsedJSON } from "./utils/helpers.ts";
+import {
+  api,
+  applyChainId,
+  isOk,
+  renderJSON,
+  renderMaybeParsedJSON,
+  toBig,
+} from "./utils/helpers.ts";
 import type {
   ApiErr,
   ApiOk,
@@ -156,7 +163,17 @@ export function App() {
 
     try {
       const request = pendingTx.request as Record<string, unknown>;
-      const { from, input, to, ...txFields } = request;
+      const {
+        from,
+        input,
+        to,
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+        gas,
+        nonce,
+        value,
+        ...txFields
+      } = request;
 
       const hash = await walletClient.sendTransaction({
         ...txFields,
@@ -166,6 +183,14 @@ export function App() {
         ...(input ? { data: input as `0x${string}` } : {}),
         // Only include 'to' if it's not null (contract creation)
         ...(to ? { to: to as Address } : {}),
+        // Convert hex-encoded numeric fields to BigInt for viem compatibility
+        ...(maxFeePerGas ? { maxFeePerGas: toBig(maxFeePerGas as `0x${string}`) } : {}),
+        ...(maxPriorityFeePerGas
+          ? { maxPriorityFeePerGas: toBig(maxPriorityFeePerGas as `0x${string}`) }
+          : {}),
+        ...(gas ? { gas: toBig(gas as `0x${string}`) } : {}),
+        ...(nonce ? { nonce: Number(toBig(nonce as `0x${string}`)) } : {}),
+        ...(value ? { value: toBig(value as `0x${string}`) } : {}),
         chain,
       });
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { type Chain, hexToBigInt } from "viem";
+import { type Chain, fromHex, hexToBigInt } from "viem";
 import * as chains from "viem/chains";
 
 import type { ApiErr, ApiOk } from "./types";
@@ -60,6 +60,8 @@ export const applyChainId = (
 };
 
 export const toBig = (h?: `0x${string}`) => (h ? hexToBigInt(h) : undefined);
+
+export const toNonce = (h?: `0x${string}`) => (h ? fromHex(h, "number") : undefined);
 
 export const api = async <T = unknown>(
   path: string,


### PR DESCRIPTION
Follow-up to #35 — addresses two remaining issues:

1. **Add `gasPrice` conversion for legacy transactions**: #35 converts EIP-1559 fee fields but misses `gasPrice`, which means legacy transactions still arrive as hex strings and fail. This destructures `gasPrice` from the request and converts it via `toBig()`, only applying it when EIP-1559 fields are absent (they're mutually exclusive per EIP-2718).

2. **Use `fromHex` for nonce conversion**: Replaces `Number(toBig(nonce))` with a dedicated `toNonce()` helper that uses viem's `fromHex(h, "number")`. The previous approach had a subtle issue: `toBig()` returns `undefined` for falsy inputs, and `Number(undefined)` is `NaN`.

Prompted by: zerosnacks