### PR TITLE
Enable release sourcemaps

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   build: {
     outDir: "dist",
     assetsDir: ".",
+    sourcemap: true,
     cssCodeSplit: false,
     modulePreload: false,
     rollupOptions: {


### PR DESCRIPTION
## Summary
- enable Vite sourcemap output for production builds
- let the existing release archive automatically include `main.js.map` from `dist/`