### PR TITLE
chore: supply chain hardening

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+onlyBuiltDependencies:
+  - "@biomejs/biome"
+  - "esbuild"
+minimumReleaseAge: 10080
+blockExoticSubdeps: true
+trustPolicy: no-downgrade
+trustPolicyIgnoreAfter: 525600


### PR DESCRIPTION
Hardens the dependency supply chain:

- `ignore-scripts=true` in `.npmrc` — blocks postinstall scripts by default
- `onlyBuiltDependencies` — allowlists only `@biomejs/biome` and `esbuild` for build scripts
- `minimumReleaseAge: 10080` — 7-day quarantine on new package versions
- `blockExoticSubdeps: true` — prevents transitive deps from using git repos or tarball URLs
- `trustPolicy: no-downgrade` — fails install if a package loses trust evidence (e.g. trusted publisher → no provenance)
- `trustPolicyIgnoreAfter: 525600` — exempts packages older than ~1 year from trust checks

Prompted by: zerosnacks