### PR TITLE
fix: override vulnerable transitive dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,10 @@
     "husky": "^9.1.7",
     "typescript": "~5.9.3",
     "vite": "^8.0.5"
+  },
+  "pnpm": {
+    "overrides": {
+      "hono": ">=4.12.12"
+    }
   }
 }


### PR DESCRIPTION
Adds pnpm overrides to force safe versions of vulnerable transitive dependencies:

- **hono** `>=4.12.12` — fixes 5 CVEs (CVSS 4.8–6.3). Transitive via `porto`.

The `axios` override was removed since `vite-plugin-mkcert` (which pulled it in) was dropped from the project.

Prompted by: zerosnacks