### PR TITLE
fix: disable source maps in production builds

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   build: {
     outDir: "dist",
     assetsDir: ".",
-    sourcemap: true,
+    sourcemap: false,
     cssCodeSplit: false,
     modulePreload: false,
     rollupOptions: {


### PR DESCRIPTION
Disables source maps in production builds by setting `sourcemap: false` in `vite.config.ts`.

While this is an open-source project, shipping source maps with a wallet application unnecessarily exposes the internal module structure and comments in browser devtools to end users.

Prompted by: zerosnacks