### PR TITLE
ci: remove shared cache from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,6 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: ".nvmrc"
-          cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm run fmt:check


### PR DESCRIPTION
Remove `cache: "pnpm"` from `setup-node` in the release workflow to prevent cache poisoning from PR builds affecting release artifacts.

Prompted by: georgen