### PR TITLE
feat: signing session + transactions history

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -528,9 +528,11 @@ account: ${account}
 chain:   ${chain ? `${chain.name} (${chainId})` : (chainId ?? "unknown")}
 rpc:     ${chain?.rpcUrls?.default?.http?.[0] ?? chain?.rpcUrls?.public?.http?.[0] ?? "unknown"}`}
             </pre>
-            <button type="button" className="wallet-disconnect" onClick={() => void disconnect()}>
-              Disconnect
-            </button>
+            <div className="disconnect-row">
+              <button type="button" className="btn btn-secondary" onClick={() => void disconnect()}>
+                Disconnect
+              </button>
+            </div>
           </>
         )}
 
@@ -538,10 +540,10 @@ rpc:     ${chain?.rpcUrls?.default?.http?.[0] ?? chain?.rpcUrls?.public?.http?.[
           <>
             <div className="section-title">Transaction to Sign &amp; Send</div>
             <div className="action-row">
-              <button type="button" className="wallet-send" onClick={signAndSendCurrentTx}>
+              <button type="button" className="btn btn-primary" onClick={signAndSendCurrentTx}>
                 Sign &amp; Send
               </button>
-              <button type="button" className="wallet-reject" onClick={() => void rejectCurrent()}>
+              <button type="button" className="btn btn-danger" onClick={() => void rejectCurrent()}>
                 Reject
               </button>
             </div>
@@ -555,10 +557,10 @@ rpc:     ${chain?.rpcUrls?.default?.http?.[0] ?? chain?.rpcUrls?.public?.http?.[
           <>
             <div className="section-title">Message / Data to Sign</div>
             <div className="action-row">
-              <button type="button" className="wallet-send" onClick={signCurrentMessage}>
+              <button type="button" className="btn btn-primary" onClick={signCurrentMessage}>
                 Sign
               </button>
-              <button type="button" className="wallet-reject" onClick={() => void rejectCurrent()}>
+              <button type="button" className="btn btn-danger" onClick={() => void rejectCurrent()}>
                 Reject
               </button>
             </div>
@@ -606,14 +608,14 @@ function HistoryCard({ entry }: { entry: HistoryEntry }) {
   if (entry.kind === "tx") {
     const summary =
       entry.status === "mined"
-        ? `mined  ${shortHash(entry.hash)}`
+        ? `mined  ${entry.hash ?? ""}`
         : entry.status === "sent"
-          ? `sent   ${shortHash(entry.hash)}  (waiting for receipt)`
+          ? `sent   ${entry.hash ?? ""}  (waiting for receipt)`
           : entry.status === "failed"
             ? `failed ${entry.error ?? ""}`
             : "pending";
     return (
-      <div className={`history-entry tx status-${entry.status}`}>
+      <div className={`history-entry tx status-${entry.status}${open ? " open" : ""}`}>
         <button
           type="button"
           className="history-summary"
@@ -622,6 +624,7 @@ function HistoryCard({ entry }: { entry: HistoryEntry }) {
         >
           <span className="history-kind">tx</span>
           <span className="history-status">{summary}</span>
+          <Chevron />
         </button>
         {open && (
           <div className="history-details">
@@ -664,7 +667,7 @@ function HistoryCard({ entry }: { entry: HistoryEntry }) {
         ? `failed ${entry.error ?? ""}`
         : "pending";
   return (
-    <div className={`history-entry sign status-${entry.status}`}>
+    <div className={`history-entry sign status-${entry.status}${open ? " open" : ""}`}>
       <button
         type="button"
         className="history-summary"
@@ -673,6 +676,7 @@ function HistoryCard({ entry }: { entry: HistoryEntry }) {
       >
         <span className="history-kind">sig</span>
         <span className="history-status">{summary}</span>
+        <Chevron />
       </button>
       {open && (
         <div className="history-details">
@@ -695,6 +699,27 @@ function HistoryCard({ entry }: { entry: HistoryEntry }) {
         </div>
       )}
     </div>
+  );
+}
+
+/// Chevron icon used in history dropdown summaries. Inherits color from
+/// its parent and is rotated 180° via CSS when the entry is open.
+function Chevron() {
+  return (
+    <svg
+      className="history-chevron"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,8 +67,8 @@ export function App() {
 
   // --- helpers ---------------------------------------------------------------
 
-  /// Insert or update a history entry by id. Newest entries are shown first
-  /// in the UI.
+  // Insert or update a history entry by id. Newest entries are shown first
+  // in the UI.
   const upsertHistory = useCallback((entry: HistoryEntry) => {
     setHistory((prev) => {
       const idx = prev.findIndex((e) => e.id === entry.id);
@@ -129,9 +129,9 @@ export function App() {
     setConfirmed(true);
   };
 
-  /// Disconnect the wallet. The Rust server will fail any in-flight request
-  /// with a "Wallet disconnected" error so the script gets fast feedback
-  /// instead of waiting for the per-request timeout.
+  // Disconnect the wallet. The Rust server will fail any in-flight request
+  // with a "Wallet disconnected" error so the script gets fast feedback
+  // instead of waiting for the per-request timeout.
   const disconnect = useCallback(async () => {
     try {
       await api("/api/connection", "POST", null);
@@ -147,9 +147,9 @@ export function App() {
 
   // --- request handlers ------------------------------------------------------
 
-  /// Sign and send the current pending transaction. Clears `pendingTx`
-  /// immediately after the wallet returns a hash so the poller can pick up
-  /// the next request without waiting for the receipt.
+  // Sign and send the current pending transaction. Clears `pendingTx`
+  // immediately after the wallet returns a hash so the poller can pick up
+  // the next request without waiting for the receipt.
   const signAndSendCurrentTx = async () => {
     if (!selected || !pendingTx?.request || !sessionAlive || isSending) return;
     setIsSending(true);
@@ -331,9 +331,9 @@ export function App() {
     }
   };
 
-  /// Reject the currently pending transaction or signing request without
-  /// touching the wallet. Lets the user skip a request while keeping the
-  /// session alive.
+  // Reject the currently pending transaction or signing request without
+  // touching the wallet. Lets the user skip a request while keeping the
+  // session alive.
   const rejectCurrent = useCallback(async () => {
     if (pendingTx) {
       const id = pendingTx.id;
@@ -751,8 +751,8 @@ function HistoryCard({ entry }: { entry: HistoryEntry }) {
   );
 }
 
-/// Chevron icon used in history dropdown summaries. Inherits color from
-/// its parent and is rotated 180° via CSS when the entry is open.
+// Chevron icon used in history dropdown summaries. Inherits color from
+// its parent and is rotated 180° via CSS when the entry is open.
 function Chevron() {
   return (
     <svg

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -546,10 +546,20 @@ rpc:     ${chain?.rpcUrls?.default?.http?.[0] ?? chain?.rpcUrls?.public?.http?.[
           <>
             <div className="section-title">Transaction to Sign &amp; Send</div>
             <div className="action-row">
-              <button type="button" className="btn btn-primary" onClick={signAndSendCurrentTx} disabled={isSending}>
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={signAndSendCurrentTx}
+                disabled={isSending}
+              >
                 Sign &amp; Send
               </button>
-              <button type="button" className="btn btn-danger" onClick={() => void rejectCurrent()} disabled={isSending}>
+              <button
+                type="button"
+                className="btn btn-danger"
+                onClick={() => void rejectCurrent()}
+                disabled={isSending}
+              >
                 Reject
               </button>
             </div>
@@ -563,10 +573,20 @@ rpc:     ${chain?.rpcUrls?.default?.http?.[0] ?? chain?.rpcUrls?.public?.http?.[
           <>
             <div className="section-title">Message / Data to Sign</div>
             <div className="action-row">
-              <button type="button" className="btn btn-primary" onClick={signCurrentMessage} disabled={isSending}>
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={signCurrentMessage}
+                disabled={isSending}
+              >
                 Sign
               </button>
-              <button type="button" className="btn btn-danger" onClick={() => void rejectCurrent()} disabled={isSending}>
+              <button
+                type="button"
+                className="btn btn-danger"
+                onClick={() => void rejectCurrent()}
+                disabled={isSending}
+              >
                 Reject
               </button>
             </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,8 +115,8 @@ export function App() {
     }
   };
 
-  /// Confirm the current connection. After this the polling loop runs and
-  /// the user no longer needs to reload between requests.
+  // Confirm the current connection. After this the polling loop runs and
+  // the user no longer needs to reload between requests.
   const confirm = async () => {
     if (!account || chainId == null) return;
 
@@ -223,20 +223,37 @@ export function App() {
         ...(value ? { value: toBig(value as `0x${string}`) } : {}),
         chain,
       });
-
-      await api("/api/transaction/response", "POST", { id, hash, error: null });
     } catch (e: unknown) {
       const msg = errMessage(e);
       console.error("send failed:", msg);
 
-      try {
-        await api("/api/transaction/response", "POST", { id, hash: null, error: msg });
-      } catch {}
-
-      updateHistory(id, "tx", { status: "failed", error: msg });
+      if (!hash) {
+        // Wallet rejected or failed before broadcasting — safe to report error.
+        try {
+          await api("/api/transaction/response", "POST", { id, hash: null, error: msg });
+        } catch {}
+        updateHistory(id, "tx", { status: "failed", error: msg });
+      } else {
+        // Tx was broadcast (hash known) but the response POST failed. Report
+        // success so the script is not left waiting; the hash is preserved in
+        // history.
+        console.warn("response post failed after broadcast, reporting hash anyway:", hash);
+        try {
+          await api("/api/transaction/response", "POST", { id, hash, error: null });
+        } catch {}
+        updateHistory(id, "tx", { status: "sent", hash });
+      }
       setPendingTx(null);
       setIsSending(false);
       return;
+    }
+
+    try {
+      await api("/api/transaction/response", "POST", { id, hash, error: null });
+    } catch (e: unknown) {
+      // Tx is already live on-chain. Log and continue — history already shows
+      // the hash.
+      console.warn("response post failed after successful send:", errMessage(e));
     }
 
     // Mark as sent and clear the pending slot so the poller can re-arm
@@ -393,11 +410,17 @@ export function App() {
     if (!selected) return;
 
     const onAccountsChanged = (accounts: readonly string[]) => {
-      if (confirmed) return;
+      if (confirmed) {
+        void disconnect();
+        return;
+      }
       setAccount((accounts[0] as Address) ?? undefined);
     };
     const onChainChanged = (raw: unknown) => {
-      if (confirmed) return;
+      if (confirmed) {
+        void disconnect();
+        return;
+      }
       applyChainId(raw, setChainId, setChain);
     };
 
@@ -407,7 +430,7 @@ export function App() {
       selected.provider.removeListener?.("accountsChanged", onAccountsChanged);
       selected.provider.removeListener?.("chainChanged", onChainChanged);
     };
-  }, [selected, confirmed]);
+  }, [selected, confirmed, disconnect]);
 
   // Combined poller: while the session is alive, we are confirmed, and there
   // is no in-flight request, look for the next transaction or signing
@@ -550,7 +573,7 @@ rpc:     ${chain?.rpcUrls?.default?.http?.[0] ?? chain?.rpcUrls?.public?.http?.[
                 type="button"
                 className="btn btn-primary"
                 onClick={signAndSendCurrentTx}
-                disabled={isSending}
+                disabled={isSending || !sessionAlive}
               >
                 Sign &amp; Send
               </button>
@@ -558,7 +581,7 @@ rpc:     ${chain?.rpcUrls?.default?.http?.[0] ?? chain?.rpcUrls?.public?.http?.[
                 type="button"
                 className="btn btn-danger"
                 onClick={() => void rejectCurrent()}
-                disabled={isSending}
+                disabled={isSending || !sessionAlive}
               >
                 Reject
               </button>
@@ -577,7 +600,7 @@ rpc:     ${chain?.rpcUrls?.default?.http?.[0] ?? chain?.rpcUrls?.public?.http?.[
                 type="button"
                 className="btn btn-primary"
                 onClick={signCurrentMessage}
-                disabled={isSending}
+                disabled={isSending || !sessionAlive}
               >
                 Sign
               </button>
@@ -585,7 +608,7 @@ rpc:     ${chain?.rpcUrls?.default?.http?.[0] ?? chain?.rpcUrls?.public?.http?.[
                 type="button"
                 className="btn btn-danger"
                 onClick={() => void rejectCurrent()}
-                disabled={isSending}
+                disabled={isSending || !sessionAlive}
               >
                 Reject
               </button>
@@ -638,7 +661,7 @@ function HistoryCard({ entry }: { entry: HistoryEntry }) {
         : entry.status === "sent"
           ? `sent   ${entry.hash ?? ""}  (waiting for receipt)`
           : entry.status === "failed"
-            ? `failed ${entry.error ?? ""}`
+            ? `failed ${(entry.error ?? "").split("\n")[0]}`
             : "pending";
     return (
       <div className={`history-entry tx status-${entry.status}${open ? " open" : ""}`}>
@@ -690,7 +713,7 @@ function HistoryCard({ entry }: { entry: HistoryEntry }) {
     entry.status === "signed"
       ? `signed ${shortHash(entry.signature)}`
       : entry.status === "failed"
-        ? `failed ${entry.error ?? ""}`
+        ? `failed ${(entry.error ?? "").split("\n")[0]}`
         : "pending";
   return (
     <div className={`history-entry sign status-${entry.status}${open ? " open" : ""}`}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,7 @@ import "./styles/App.css";
 
 import { Provider } from "accounts";
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  type Address,
-  type Chain,
-  createWalletClient,
-  custom,
-  type TransactionReceipt,
-} from "viem";
+import { type Address, type Chain, createWalletClient, custom, type Hex } from "viem";
 import { waitForTransactionReceipt } from "viem/actions";
 
 import {
@@ -26,9 +20,16 @@ import type {
   EIP1193,
   EIP6963AnnounceProviderEvent,
   EIP6963ProviderInfo,
+  HistoryEntry,
   PendingAny,
   PendingSigning,
+  SessionInfo,
+  SignHistoryEntry,
+  TxHistoryEntry,
 } from "./utils/types.ts";
+
+const POLL_REQUEST_INTERVAL_MS = 1000;
+const POLL_SESSION_INTERVAL_MS = 3000;
 
 export function App() {
   useEffect(() => {
@@ -40,24 +41,61 @@ export function App() {
   const [providers, setProviders] = useState<{ info: EIP6963ProviderInfo; provider: EIP1193 }[]>(
     [],
   );
-
-  const [confirmed, setConfirmed] = useState<boolean>(false);
-  const [pendingTx, setPendingTx] = useState<PendingAny | null>(null);
-  const [pendingSigning, setPendingSigning] = useState<PendingSigning | null>(null);
   const [selectedUuid, setSelectedUuid] = useState<string | null>(null);
   const selected = providers.find((p) => p.info.uuid === selectedUuid) ?? null;
 
   const [account, setAccount] = useState<Address>();
   const [chainId, setChainId] = useState<number>();
   const [chain, setChain] = useState<Chain>();
+  const [confirmed, setConfirmed] = useState<boolean>(false);
 
-  const [lastTxReceipt, setLastTxReceipt] = useState<TransactionReceipt | null>(null);
-  const [lastTxHash, setLastTxHash] = useState<string | null>(null);
-  const [lastSignature, setLastSignature] = useState<string | null>(null);
+  const [pendingTx, setPendingTx] = useState<PendingAny | null>(null);
+  const [pendingSigning, setPendingSigning] = useState<PendingSigning | null>(null);
 
-  const pollTxRef = useRef<number | null>(null);
-  const pollSigningRef = useRef<number | null>(null);
+  // In-session history of every signed transaction and message. Flushed on
+  // page reload (issue foundry-rs/foundry-browser-wallet#17).
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+
+  // Tracks whether the BrowserSigner server is still alive. Becomes false
+  // either when `/api/session` reports `alive: false` or when polling fails
+  // (server gone). When false, polling is paused and the UI shows an
+  // "end of session" badge while keeping the history visible.
+  const [sessionAlive, setSessionAlive] = useState<boolean>(true);
+
   const prevSelectedUuidRef = useRef<string | null>(null);
+
+  // --- helpers ---------------------------------------------------------------
+
+  /// Insert or update a history entry by id. Newest entries are shown first
+  /// in the UI.
+  const upsertHistory = useCallback((entry: HistoryEntry) => {
+    setHistory((prev) => {
+      const idx = prev.findIndex((e) => e.id === entry.id);
+      if (idx === -1) {
+        return [entry, ...prev];
+      }
+      const next = prev.slice();
+      next[idx] = entry;
+      return next;
+    });
+  }, []);
+
+  const updateHistory = useCallback(
+    <K extends HistoryEntry["kind"]>(
+      id: string,
+      kind: K,
+      patch: Partial<Extract<HistoryEntry, { kind: K }>>,
+    ) => {
+      setHistory((prev) =>
+        prev.map((e) =>
+          e.id === id && e.kind === kind ? ({ ...e, ...patch } as HistoryEntry) : e,
+        ),
+      );
+    },
+    [],
+  );
+
+  // --- wallet connection -----------------------------------------------------
 
   const connect = async () => {
     if (!selected || confirmed) return;
@@ -76,15 +114,13 @@ export function App() {
     }
   };
 
-  // Confirm the current connection.
-  // This is required for Foundry to fill out the `from` field and `chain` in transactions.
+  /// Confirm the current connection. After this the polling loop runs and
+  /// the user no longer needs to reload between requests.
   const confirm = async () => {
-    if (!account || chainId == null) {
-      return;
-    }
+    if (!account || chainId == null) return;
 
     try {
-      await api("/api/connection", "POST", [account, chainId]);
+      await api("/api/connection", "POST", { address: account, chainId });
     } catch {
       return;
     }
@@ -92,78 +128,52 @@ export function App() {
     setConfirmed(true);
   };
 
-  const signCurrentMessage = async () => {
-    if (!selected || !pendingSigning) return;
-
-    const { id, signType, request } = pendingSigning;
-    const signer = request.address;
-    const msg = request.message;
-
+  /// Disconnect the wallet. The Rust server will fail any in-flight request
+  /// with a "Wallet disconnected" error so the script gets fast feedback
+  /// instead of waiting for the per-request timeout.
+  const disconnect = useCallback(async () => {
     try {
-      let signature: string;
+      await api("/api/connection", "POST", null);
+    } catch {}
 
-      switch (signType) {
-        case "PersonalSign":
-          // Standard message signing
-          signature = (await selected.provider.request({
-            method: "personal_sign",
-            params: [msg, signer],
-          })) as string;
-          break;
+    setPendingTx(null);
+    setPendingSigning(null);
+    setAccount(undefined);
+    setChainId(undefined);
+    setChain(undefined);
+    setConfirmed(false);
+  }, []);
 
-        case "SignTypedDataV4":
-          // EIP-712 typed data signing
-          signature = (await selected.provider.request({
-            method: "eth_signTypedData_v4",
-            params: [signer, msg],
-          })) as string;
-          break;
+  // --- request handlers ------------------------------------------------------
 
-        default:
-          throw new Error(`Unsupported signType: ${signType}`);
-      }
-
-      await api("/api/signing/response", "POST", {
-        id,
-        signature,
-        error: null,
-      });
-
-      setLastSignature(signature);
-      setPendingSigning(null);
-    } catch (e: unknown) {
-      const errMsg =
-        typeof e === "object" &&
-        e &&
-        "message" in e &&
-        typeof (e as { message?: unknown }).message === "string"
-          ? (e as { message: string }).message
-          : String(e);
-
-      try {
-        await api("/api/signing/response", "POST", {
-          id,
-          signature: null,
-          error: errMsg,
-        });
-      } catch {}
-
-      setLastSignature(null);
-      setPendingSigning(null);
-    }
-  };
-
-  // Sign and send the current pending transaction.
+  /// Sign and send the current pending transaction. Clears `pendingTx`
+  /// immediately after the wallet returns a hash so the poller can pick up
+  /// the next request without waiting for the receipt.
   const signAndSendCurrentTx = async () => {
     if (!selected || !pendingTx?.request) return;
+
+    const id = pendingTx.id;
+    const reqRecord = pendingTx.request as Record<string, unknown>;
+
+    // Push a placeholder history entry immediately so the user sees the
+    // request being processed even if signing takes a while.
+    const placeholder: TxHistoryEntry = {
+      kind: "tx",
+      id,
+      ts: Date.now(),
+      request: reqRecord,
+      status: "pending",
+    };
+    upsertHistory(placeholder);
 
     const walletClient = createWalletClient({
       transport: custom(selected.provider),
       chain,
     });
 
+    let hash: Hex | undefined;
+
     try {
-      const request = pendingTx.request as Record<string, unknown>;
       const {
         from,
         input,
@@ -176,16 +186,17 @@ export function App() {
         value,
         calls,
         ...txFields
-      } = request;
+      } = reqRecord;
 
-      // The Tempo accounts SDK's eth_sendTransaction handler uses nullish coalescing
-      // to fall back from calls[] to {to, data} — but an empty array [] is truthy
-      // and bypasses the fallback. Omit calls when empty so the SDK correctly
-      // converts to+data into a call entry.
+      // The Tempo accounts SDK's eth_sendTransaction handler uses nullish
+      // coalescing to fall back from calls[] to {to, data} — but an empty
+      // array [] is truthy and bypasses the fallback. Omit calls when empty
+      // so the SDK correctly converts to+data into a call entry.
       const resolvedCalls = Array.isArray(calls) && calls.length > 0 ? { calls } : {};
 
-      // Convert hex-encoded numeric fields to BigInt/number for viem compatibility.
-      // gasPrice (legacy) and EIP-1559 fee fields are mutually exclusive.
+      // Convert hex-encoded numeric fields to BigInt/number for viem
+      // compatibility. gasPrice (legacy) and EIP-1559 fee fields are
+      // mutually exclusive.
       const feeFields =
         maxFeePerGas || maxPriorityFeePerGas
           ? {
@@ -198,14 +209,11 @@ export function App() {
               ...(gasPrice ? { gasPrice: toBig(gasPrice as `0x${string}`) } : {}),
             };
 
-      const hash = await walletClient.sendTransaction({
+      hash = await walletClient.sendTransaction({
         ...txFields,
         ...resolvedCalls,
-        // Viem uses 'account' instead of 'from' at the action level
         account: (from as Address) || (await walletClient.getAddresses())[0],
-        // Viem uses 'data' for contract bytecode (from 'input' field in the API)
         ...(input ? { data: input as `0x${string}` } : {}),
-        // Only include 'to' if it's not null (contract creation)
         ...(to ? { to: to as Address } : {}),
         ...feeFields,
         ...(gas ? { gas: toBig(gas as `0x${string}`) } : {}),
@@ -214,70 +222,145 @@ export function App() {
         chain,
       });
 
-      setLastTxHash(hash);
-
-      await api("/api/transaction/response", "POST", { id: pendingTx.id, hash, error: null });
-
-      const receipt = await waitForTransactionReceipt(walletClient, { hash });
-      setLastTxReceipt(receipt);
+      await api("/api/transaction/response", "POST", { id, hash, error: null });
     } catch (e: unknown) {
-      const msg =
-        typeof e === "object" &&
-        e &&
-        "message" in e &&
-        typeof (e as { message?: unknown }).message === "string"
-          ? (e as { message: string }).message
-          : String(e);
-
+      const msg = errMessage(e);
       console.error("send failed:", msg);
 
       try {
-        await api("/api/transaction/response", "POST", {
-          id: pendingTx.id,
-          hash: null,
-          error: msg,
-        });
+        await api("/api/transaction/response", "POST", { id, hash: null, error: msg });
       } catch {}
+
+      updateHistory(id, "tx", { status: "failed", error: msg });
+      setPendingTx(null);
+      return;
+    }
+
+    // Mark as sent and clear the pending slot so the poller can re-arm
+    // immediately for the next request.
+    updateHistory(id, "tx", { status: "sent", hash });
+    setPendingTx(null);
+
+    // Fetch the receipt in the background; it'll update the entry when
+    // ready. Failures here only affect the displayed receipt, never the
+    // signing flow.
+    void (async () => {
+      try {
+        const receipt = await waitForTransactionReceipt(walletClient, { hash: hash as Hex });
+        updateHistory(id, "tx", { status: "mined", receipt });
+      } catch (e) {
+        const msg = errMessage(e);
+        updateHistory(id, "tx", { status: "failed", error: msg });
+      }
+    })();
+  };
+
+  /// Sign the current pending message / typed data.
+  const signCurrentMessage = async () => {
+    if (!selected || !pendingSigning) return;
+
+    const { id, signType, request } = pendingSigning;
+    const signer = request.address;
+    const msg = request.message;
+
+    const placeholder: SignHistoryEntry = {
+      kind: "sign",
+      id,
+      ts: Date.now(),
+      signType,
+      request,
+      status: "pending",
+    };
+    upsertHistory(placeholder);
+
+    try {
+      let signature: Hex;
+      switch (signType) {
+        case "PersonalSign":
+          signature = (await selected.provider.request({
+            method: "personal_sign",
+            params: [msg, signer],
+          })) as Hex;
+          break;
+        case "SignTypedDataV4":
+          signature = (await selected.provider.request({
+            method: "eth_signTypedData_v4",
+            params: [signer, msg],
+          })) as Hex;
+          break;
+        default:
+          throw new Error(`Unsupported signType: ${signType}`);
+      }
+
+      await api("/api/signing/response", "POST", { id, signature, error: null });
+
+      updateHistory(id, "sign", { status: "signed", signature });
+    } catch (e: unknown) {
+      const msg = errMessage(e);
+
+      try {
+        await api("/api/signing/response", "POST", { id, signature: null, error: msg });
+      } catch {}
+
+      updateHistory(id, "sign", { status: "failed", error: msg });
+    } finally {
+      setPendingSigning(null);
     }
   };
 
-  // Reset all client state.
-  const resetClientState = useCallback(() => {
-    if (pollTxRef.current) {
-      window.clearInterval(pollTxRef.current);
-      pollTxRef.current = null;
+  /// Reject the currently pending transaction or signing request without
+  /// touching the wallet. Lets the user skip a request while keeping the
+  /// session alive.
+  const rejectCurrent = useCallback(async () => {
+    if (pendingTx) {
+      const id = pendingTx.id;
+      const reason = "Rejected by user";
+      try {
+        await api("/api/transaction/response", "POST", { id, hash: null, error: reason });
+      } catch {}
+      upsertHistory({
+        kind: "tx",
+        id,
+        ts: Date.now(),
+        request: pendingTx.request as Record<string, unknown>,
+        status: "failed",
+        error: reason,
+      });
+      setPendingTx(null);
+      return;
     }
-
-    if (pollSigningRef.current) {
-      window.clearInterval(pollSigningRef.current);
-      pollSigningRef.current = null;
+    if (pendingSigning) {
+      const { id, signType, request } = pendingSigning;
+      const reason = "Rejected by user";
+      try {
+        await api("/api/signing/response", "POST", { id, signature: null, error: reason });
+      } catch {}
+      upsertHistory({
+        kind: "sign",
+        id,
+        ts: Date.now(),
+        signType,
+        request,
+        status: "failed",
+        error: reason,
+      });
+      setPendingSigning(null);
     }
+  }, [pendingTx, pendingSigning, upsertHistory]);
 
-    setPendingTx(null);
-    setPendingSigning(null);
-    setLastTxHash(null);
-    setLastTxReceipt(null);
+  // --- effects ---------------------------------------------------------------
 
-    setAccount(undefined);
-    setChainId(undefined);
-    setChain(undefined);
-    setConfirmed(false);
-
-    void api("/api/connection", "POST", null);
-  }, []);
-
-  // Upon switching wallets, reset state.
+  // Reset client state when switching wallets.
   useEffect(() => {
     if (
       prevSelectedUuidRef.current &&
       selectedUuid &&
       prevSelectedUuidRef.current !== selectedUuid
     ) {
-      void resetClientState();
+      void disconnect();
     }
-
     prevSelectedUuidRef.current = selectedUuid;
-  }, [selectedUuid, resetClientState]);
+  }, [selectedUuid, disconnect]);
 
   // Auto-select if only one wallet is available.
   useEffect(() => {
@@ -290,15 +373,12 @@ export function App() {
   useEffect(() => {
     const onAnnounce = (ev: EIP6963AnnounceProviderEvent) => {
       const { info, provider } = ev.detail;
-
       setProviders((prev) =>
         prev.some((p) => p.info.uuid === info.uuid) ? prev : [...prev, { info, provider }],
       );
     };
-
     window.addEventListener("eip6963:announceProvider", onAnnounce);
     window.dispatchEvent(new Event("eip6963:requestProvider"));
-
     return () => window.removeEventListener("eip6963:announceProvider", onAnnounce);
   }, []);
 
@@ -308,86 +388,81 @@ export function App() {
 
     const onAccountsChanged = (accounts: readonly string[]) => {
       if (confirmed) return;
-
       setAccount((accounts[0] as Address) ?? undefined);
     };
-
     const onChainChanged = (raw: unknown) => {
       if (confirmed) return;
-
       applyChainId(raw, setChainId, setChain);
     };
 
     selected.provider.on?.("accountsChanged", onAccountsChanged);
     selected.provider.on?.("chainChanged", onChainChanged);
-
     return () => {
       selected.provider.removeListener?.("accountsChanged", onAccountsChanged);
       selected.provider.removeListener?.("chainChanged", onChainChanged);
     };
   }, [selected, confirmed]);
 
-  // Poll for pending transaction requests.
-  // Stops when one is found or when a pending signing request is found.
+  // Combined poller: while the session is alive, we are confirmed, and there
+  // is no in-flight request, look for the next transaction or signing
+  // request. Polling re-arms automatically as soon as
+  // `pendingTx`/`pendingSigning` are cleared by the completion handlers.
   useEffect(() => {
-    if (!confirmed || pendingTx || pendingSigning) return;
+    if (!confirmed || pendingTx || pendingSigning || !sessionAlive) return;
 
     let active = true;
-
     const id = window.setInterval(async () => {
       if (!active) return;
+
       try {
-        const resp = await api<ApiOk<PendingAny> | ApiErr>("/api/transaction/request");
-        if (isOk(resp)) {
-          window.clearInterval(id);
-          if (active) {
-            setPendingTx(resp.data);
-          }
+        const tx = await api<ApiOk<PendingAny> | ApiErr>("/api/transaction/request");
+        if (isOk(tx)) {
+          if (active) setPendingTx(tx.data);
+          return;
         }
       } catch {}
-    }, 1000);
 
-    pollTxRef.current = id;
+      try {
+        const sig = await api<ApiOk<PendingSigning> | ApiErr>("/api/signing/request");
+        if (isOk(sig)) {
+          if (active) setPendingSigning(sig.data);
+        }
+      } catch {}
+    }, POLL_REQUEST_INTERVAL_MS);
 
     return () => {
       active = false;
       window.clearInterval(id);
-      if (pollTxRef.current === id) {
-        pollTxRef.current = null;
+    };
+  }, [confirmed, pendingTx, pendingSigning, sessionAlive]);
+
+  // Session liveness poller: detect when the BrowserSigner server is gone
+  // (script finished, server stopped) so we can stop spamming the request
+  // endpoints and surface a clean "session ended" UI.
+  useEffect(() => {
+    let active = true;
+    const tick = async () => {
+      try {
+        const resp = await api<ApiOk<SessionInfo> | ApiErr>("/api/session");
+        if (!active) return;
+        if (isOk(resp)) {
+          setSessionAlive(resp.data.alive);
+        } else {
+          setSessionAlive(false);
+        }
+      } catch {
+        if (active) setSessionAlive(false);
       }
     };
-  }, [confirmed, pendingTx, pendingSigning]);
-
-  // Poll for pending signing requests.
-  // Stops when one is found or when a pending transaction request is found.
-  useEffect(() => {
-    if (!confirmed || pendingSigning || pendingTx) return;
-
-    let active = true;
-
-    const id = window.setInterval(async () => {
-      if (!active) return;
-      try {
-        const resp = await api<ApiOk<PendingSigning> | ApiErr>("/api/signing/request");
-        if (isOk(resp)) {
-          window.clearInterval(id);
-          if (active) {
-            setPendingSigning(resp.data);
-          }
-        }
-      } catch {}
-    }, 1000);
-
-    pollSigningRef.current = id;
-
+    void tick();
+    const id = window.setInterval(tick, POLL_SESSION_INTERVAL_MS);
     return () => {
       active = false;
       window.clearInterval(id);
-      if (pollSigningRef.current === id) {
-        pollSigningRef.current = null;
-      }
     };
-  }, [confirmed, pendingSigning, pendingTx]);
+  }, []);
+
+  // --- render ---------------------------------------------------------------
 
   return (
     <div className="wrapper">
@@ -397,6 +472,12 @@ export function App() {
         </div>
 
         <img className="banner" src="banner.png" alt="Foundry Browser Wallet" />
+
+        {!sessionAlive && (
+          <div className="session-ended">
+            Session ended. The script has finished or the server is no longer reachable.
+          </div>
+        )}
 
         {providers.length > 1 && (
           <div className="wallet-selector">
@@ -438,7 +519,7 @@ export function App() {
           </button>
         )}
 
-        {selected && account && (
+        {selected && account && confirmed && (
           <>
             <div className="section-title">Connected</div>
             <pre className="box">
@@ -447,30 +528,23 @@ account: ${account}
 chain:   ${chain ? `${chain.name} (${chainId})` : (chainId ?? "unknown")}
 rpc:     ${chain?.rpcUrls?.default?.http?.[0] ?? chain?.rpcUrls?.public?.http?.[0] ?? "unknown"}`}
             </pre>
+            <button type="button" className="wallet-disconnect" onClick={() => void disconnect()}>
+              Disconnect
+            </button>
           </>
         )}
 
-        {selected &&
-          account &&
-          confirmed &&
-          !pendingTx &&
-          !pendingSigning &&
-          !lastTxHash &&
-          !lastSignature && (
-            <>
-              <div className="section-title">Transaction To Sign</div>
-              <div className="box">
-                <pre>No pending transaction or signing request</pre>
-              </div>
-            </>
-          )}
-
-        {selected && account && confirmed && !lastTxHash && pendingTx && (
+        {selected && account && confirmed && pendingTx && (
           <>
-            <div className="section-title">Transaction to Sign & Send</div>
-            <button type="button" className="wallet-send" onClick={signAndSendCurrentTx}>
-              Sign &amp; Send
-            </button>
+            <div className="section-title">Transaction to Sign &amp; Send</div>
+            <div className="action-row">
+              <button type="button" className="wallet-send" onClick={signAndSendCurrentTx}>
+                Sign &amp; Send
+              </button>
+              <button type="button" className="wallet-reject" onClick={() => void rejectCurrent()}>
+                Reject
+              </button>
+            </div>
             <div className="box">
               <pre>{renderJSON(pendingTx.request)}</pre>
             </div>
@@ -480,36 +554,162 @@ rpc:     ${chain?.rpcUrls?.default?.http?.[0] ?? chain?.rpcUrls?.public?.http?.[
         {selected && account && confirmed && !pendingTx && pendingSigning && (
           <>
             <div className="section-title">Message / Data to Sign</div>
-            <button type="button" className="wallet-send" onClick={signCurrentMessage}>
-              Sign
-            </button>
+            <div className="action-row">
+              <button type="button" className="wallet-send" onClick={signCurrentMessage}>
+                Sign
+              </button>
+              <button type="button" className="wallet-reject" onClick={() => void rejectCurrent()}>
+                Reject
+              </button>
+            </div>
             <div className="box">
               <pre>{renderMaybeParsedJSON(pendingSigning.request)}</pre>
             </div>
           </>
         )}
 
-        {selected && account && lastTxHash && (
-          <>
-            <div className="section-title">Transaction Hash</div>
-            <pre className="box">{lastTxHash}</pre>
+        {selected &&
+          account &&
+          confirmed &&
+          !pendingTx &&
+          !pendingSigning &&
+          history.length === 0 &&
+          sessionAlive && (
+            <>
+              <div className="section-title">Waiting</div>
+              <div className="box">
+                <pre>No pending transaction or signing request</pre>
+              </div>
+            </>
+          )}
 
-            <div>
-              <div className="section-title">Receipt</div>
-              <pre className="box">
-                {lastTxReceipt ? renderJSON(lastTxReceipt) : "Waiting for receipt..."}
-              </pre>
+        {history.length > 0 && (
+          <>
+            <div className="section-title">Session history</div>
+            <div className="history">
+              {history.map((entry) => (
+                <HistoryCard key={entry.id} entry={entry} />
+              ))}
             </div>
-          </>
-        )}
-
-        {selected && account && confirmed && lastSignature && (
-          <>
-            <div className="section-title">Signature Result</div>
-            <pre className="box">{lastSignature}</pre>
           </>
         )}
       </div>
     </div>
   );
+}
+
+// --- subcomponents ----------------------------------------------------------
+
+function HistoryCard({ entry }: { entry: HistoryEntry }) {
+  const [open, setOpen] = useState(false);
+
+  if (entry.kind === "tx") {
+    const summary =
+      entry.status === "mined"
+        ? `mined  ${shortHash(entry.hash)}`
+        : entry.status === "sent"
+          ? `sent   ${shortHash(entry.hash)}  (waiting for receipt)`
+          : entry.status === "failed"
+            ? `failed ${entry.error ?? ""}`
+            : "pending";
+    return (
+      <div className={`history-entry tx status-${entry.status}`}>
+        <button
+          type="button"
+          className="history-summary"
+          onClick={() => setOpen((o) => !o)}
+          aria-expanded={open}
+        >
+          <span className="history-kind">tx</span>
+          <span className="history-status">{summary}</span>
+        </button>
+        {open && (
+          <div className="history-details">
+            <div className="section-subtitle">Request</div>
+            <pre className="box">{renderJSON(entry.request)}</pre>
+            {entry.hash && (
+              <>
+                <div className="section-subtitle">Hash</div>
+                <pre className="box">{entry.hash}</pre>
+              </>
+            )}
+            {entry.receipt && (
+              <>
+                <div className="section-subtitle">Receipt</div>
+                <pre className="box">{renderJSON(entry.receipt)}</pre>
+              </>
+            )}
+            {entry.status === "sent" && !entry.receipt && (
+              <>
+                <div className="section-subtitle">Receipt</div>
+                <pre className="box">Waiting for receipt…</pre>
+              </>
+            )}
+            {entry.error && (
+              <>
+                <div className="section-subtitle">Error</div>
+                <pre className="box error">{entry.error}</pre>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  const summary =
+    entry.status === "signed"
+      ? `signed ${shortHash(entry.signature)}`
+      : entry.status === "failed"
+        ? `failed ${entry.error ?? ""}`
+        : "pending";
+  return (
+    <div className={`history-entry sign status-${entry.status}`}>
+      <button
+        type="button"
+        className="history-summary"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+      >
+        <span className="history-kind">sig</span>
+        <span className="history-status">{summary}</span>
+      </button>
+      {open && (
+        <div className="history-details">
+          <div className="section-subtitle">Type</div>
+          <pre className="box">{entry.signType}</pre>
+          <div className="section-subtitle">Request</div>
+          <pre className="box">{renderMaybeParsedJSON(entry.request)}</pre>
+          {entry.signature && (
+            <>
+              <div className="section-subtitle">Signature</div>
+              <pre className="box">{entry.signature}</pre>
+            </>
+          )}
+          {entry.error && (
+            <>
+              <div className="section-subtitle">Error</div>
+              <pre className="box error">{entry.error}</pre>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// --- utilities --------------------------------------------------------------
+
+function shortHash(h?: string): string {
+  if (!h) return "";
+  return h.length > 18 ? `${h.slice(0, 10)}…${h.slice(-8)}` : h;
+}
+
+function errMessage(e: unknown): string {
+  return typeof e === "object" &&
+    e &&
+    "message" in e &&
+    typeof (e as { message?: unknown }).message === "string"
+    ? (e as { message: string }).message
+    : String(e);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,6 +51,7 @@ export function App() {
 
   const [pendingTx, setPendingTx] = useState<PendingAny | null>(null);
   const [pendingSigning, setPendingSigning] = useState<PendingSigning | null>(null);
+  const [isSending, setIsSending] = useState<boolean>(false);
 
   // In-session history of every signed transaction and message. Flushed on
   // page reload (issue foundry-rs/foundry-browser-wallet#17).
@@ -150,7 +151,8 @@ export function App() {
   /// immediately after the wallet returns a hash so the poller can pick up
   /// the next request without waiting for the receipt.
   const signAndSendCurrentTx = async () => {
-    if (!selected || !pendingTx?.request) return;
+    if (!selected || !pendingTx?.request || !sessionAlive || isSending) return;
+    setIsSending(true);
 
     const id = pendingTx.id;
     const reqRecord = pendingTx.request as Record<string, unknown>;
@@ -233,6 +235,7 @@ export function App() {
 
       updateHistory(id, "tx", { status: "failed", error: msg });
       setPendingTx(null);
+      setIsSending(false);
       return;
     }
 
@@ -240,6 +243,7 @@ export function App() {
     // immediately for the next request.
     updateHistory(id, "tx", { status: "sent", hash });
     setPendingTx(null);
+    setIsSending(false);
 
     // Fetch the receipt in the background; it'll update the entry when
     // ready. Failures here only affect the displayed receipt, never the
@@ -257,7 +261,8 @@ export function App() {
 
   /// Sign the current pending message / typed data.
   const signCurrentMessage = async () => {
-    if (!selected || !pendingSigning) return;
+    if (!selected || !pendingSigning || !sessionAlive || isSending) return;
+    setIsSending(true);
 
     const { id, signType, request } = pendingSigning;
     const signer = request.address;
@@ -305,6 +310,7 @@ export function App() {
       updateHistory(id, "sign", { status: "failed", error: msg });
     } finally {
       setPendingSigning(null);
+      setIsSending(false);
     }
   };
 
@@ -536,14 +542,14 @@ rpc:     ${chain?.rpcUrls?.default?.http?.[0] ?? chain?.rpcUrls?.public?.http?.[
           </>
         )}
 
-        {selected && account && confirmed && pendingTx && (
+        {selected && account && confirmed && sessionAlive && pendingTx && (
           <>
             <div className="section-title">Transaction to Sign &amp; Send</div>
             <div className="action-row">
-              <button type="button" className="btn btn-primary" onClick={signAndSendCurrentTx}>
+              <button type="button" className="btn btn-primary" onClick={signAndSendCurrentTx} disabled={isSending}>
                 Sign &amp; Send
               </button>
-              <button type="button" className="btn btn-danger" onClick={() => void rejectCurrent()}>
+              <button type="button" className="btn btn-danger" onClick={() => void rejectCurrent()} disabled={isSending}>
                 Reject
               </button>
             </div>
@@ -553,14 +559,14 @@ rpc:     ${chain?.rpcUrls?.default?.http?.[0] ?? chain?.rpcUrls?.public?.http?.[
           </>
         )}
 
-        {selected && account && confirmed && !pendingTx && pendingSigning && (
+        {selected && account && confirmed && sessionAlive && !pendingTx && pendingSigning && (
           <>
             <div className="section-title">Message / Data to Sign</div>
             <div className="action-row">
-              <button type="button" className="btn btn-primary" onClick={signCurrentMessage}>
+              <button type="button" className="btn btn-primary" onClick={signCurrentMessage} disabled={isSending}>
                 Sign
               </button>
-              <button type="button" className="btn btn-danger" onClick={() => void rejectCurrent()}>
+              <button type="button" className="btn btn-danger" onClick={() => void rejectCurrent()} disabled={isSending}>
                 Reject
               </button>
             </div>

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -14,7 +14,7 @@
   background-color: #3b3b3b;
   padding: 16px;
   width: 100%;
-  max-width: 600px;
+  max-width: 700px;
   border-radius: 8px;
 }
 
@@ -54,21 +54,61 @@
   margin-top: 16px;
 }
 
-.wallet-disconnect {
-  align-self: center;
-  margin-top: 4px;
-  margin-bottom: 16px;
+/* Unified button system used by all session-level actions
+   (Disconnect, Sign / Sign & Send, Reject). Shared sizing and shape;
+   the variant modifier only changes the color treatment so that the
+   action's intent is immediately legible. */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 14px;
+  border-radius: 6px;
+  border: 1px solid transparent;
   background-color: transparent;
   color: #f8f8f8;
-  border: 1px solid #888;
-  padding: 4px 12px;
-  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.2;
   cursor: pointer;
-  font-size: 12px;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease;
 }
 
-.wallet-disconnect:hover {
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background-color: #3a7afe;
+  border-color: #3a7afe;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background-color: #2f66d9;
+  border-color: #2f66d9;
+}
+
+.btn-secondary {
+  border-color: #888;
+}
+
+.btn-secondary:hover:not(:disabled) {
   background-color: #555;
+  border-color: #aaa;
+}
+
+.btn-danger {
+  border-color: #c44;
+  color: #ffb3b3;
+}
+
+.btn-danger:hover:not(:disabled) {
+  background-color: #c44;
+  color: #f8f8f8;
 }
 
 .action-row {
@@ -79,21 +119,10 @@
   margin-bottom: 16px;
 }
 
-.wallet-send {
-  cursor: pointer;
-}
-
-.wallet-reject {
-  background-color: transparent;
-  color: #f8f8f8;
-  border: 1px solid #c44;
-  padding: 4px 12px;
-  border-radius: 6px;
-  cursor: pointer;
-}
-
-.wallet-reject:hover {
-  background-color: #c44;
+.disconnect-row {
+  align-self: center;
+  margin-top: 4px;
+  margin-bottom: 16px;
 }
 
 .title,
@@ -146,6 +175,19 @@
   border: 1px solid #555;
   border-radius: 6px;
   background-color: #2f2f2f;
+  overflow: hidden;
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.history-entry:hover {
+  border-color: #777;
+}
+
+.history-entry.open {
+  border-color: #888;
+  box-shadow: 0 0 0 1px #555 inset;
 }
 
 .history-entry.status-mined,
@@ -178,10 +220,21 @@
   cursor: pointer;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 13px;
+  transition: background-color 120ms ease;
 }
 
 .history-summary:hover {
   background-color: #3a3a3a;
+}
+
+.history-summary:focus-visible {
+  outline: 2px solid #3a7afe;
+  outline-offset: -2px;
+}
+
+.history-entry.open .history-summary {
+  background-color: #353535;
+  border-bottom: 1px solid #555;
 }
 
 .history-kind {
@@ -197,6 +250,27 @@
   word-break: break-all;
 }
 
+.history-chevron {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  color: #aaa;
+  transition:
+    transform 200ms ease,
+    color 120ms ease;
+  transform-origin: center;
+}
+
+.history-summary:hover .history-chevron {
+  color: #f8f8f8;
+}
+
+.history-entry.open .history-chevron {
+  transform: rotate(180deg);
+  color: #f8f8f8;
+}
+
 .history-details {
-  padding: 4px 12px 12px;
+  padding: 8px 12px 12px;
+  background-color: #2a2a2a;
 }

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -10,9 +10,10 @@
 .container {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: stretch;
   background-color: #3b3b3b;
   padding: 16px;
+  width: 100%;
   max-width: 600px;
   border-radius: 8px;
 }
@@ -29,6 +30,17 @@
   font-size: 13px;
 }
 
+.session-ended {
+  width: 100%;
+  background-color: #555;
+  color: #f8f8f8;
+  text-align: center;
+  padding: 8px;
+  border-radius: 8px;
+  margin-top: 12px;
+  font-size: 13px;
+}
+
 .banner {
   width: 100%;
   height: auto;
@@ -37,18 +49,56 @@
 
 .wallet-selector,
 .wallet-connect,
-.wallet-send,
 .wallet-confirm {
   align-self: center;
   margin-top: 16px;
 }
 
-.wallet-send {
+.wallet-disconnect {
+  align-self: center;
+  margin-top: 4px;
+  margin-bottom: 16px;
+  background-color: transparent;
+  color: #f8f8f8;
+  border: 1px solid #888;
+  padding: 4px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.wallet-disconnect:hover {
+  background-color: #555;
+}
+
+.action-row {
+  display: flex;
+  gap: 8px;
+  align-self: center;
+  margin-top: 16px;
   margin-bottom: 16px;
 }
 
+.wallet-send {
+  cursor: pointer;
+}
+
+.wallet-reject {
+  background-color: transparent;
+  color: #f8f8f8;
+  border: 1px solid #c44;
+  padding: 4px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.wallet-reject:hover {
+  background-color: #c44;
+}
+
 .title,
-.section-title {
+.section-title,
+.section-subtitle {
   color: #f8f8f8;
 }
 
@@ -58,14 +108,95 @@
 }
 
 .section-title {
-  font-size: 24px;
-  margin-bottom: 16px;
+  font-size: 20px;
+  margin-top: 16px;
+  margin-bottom: 8px;
+}
+
+.section-subtitle {
+  font-size: 13px;
+  margin-top: 8px;
+  margin-bottom: 4px;
+  font-weight: bold;
+  color: #cfcfcf;
 }
 
 .box {
   font-size: 13px;
-  margin-bottom: 16px;
+  margin-bottom: 8px;
   border: 1px solid #e1e4e8;
   border-radius: 8px;
   padding: 8px 12px;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.box.error {
+  border-color: #c44;
+  color: #ffb3b3;
+}
+
+.history {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.history-entry {
+  border: 1px solid #555;
+  border-radius: 6px;
+  background-color: #2f2f2f;
+}
+
+.history-entry.status-mined,
+.history-entry.status-signed {
+  border-left: 3px solid #5cd178;
+}
+
+.history-entry.status-sent {
+  border-left: 3px solid #f0c040;
+}
+
+.history-entry.status-failed {
+  border-left: 3px solid #c44;
+}
+
+.history-entry.status-pending {
+  border-left: 3px solid #888;
+}
+
+.history-summary {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  color: #f8f8f8;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 13px;
+}
+
+.history-summary:hover {
+  background-color: #3a3a3a;
+}
+
+.history-kind {
+  font-weight: bold;
+  color: #cfcfcf;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  min-width: 32px;
+}
+
+.history-status {
+  flex: 1;
+  word-break: break-all;
+}
+
+.history-details {
+  padding: 4px 12px 12px;
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -62,24 +62,24 @@ export type ApiErr = { status: string; message?: string };
 
 export type PendingAny = Record<string, unknown> & { id: string; request: TransactionRequest };
 
-/// Mirrors the `SessionInfo` type returned by `GET /api/session` from the
-/// Rust BrowserWalletServer.
+// Mirrors the `SessionInfo` type returned by `GET /api/session` from the
+// Rust BrowserWalletServer.
 export type SessionInfo = {
   alive: boolean;
   connected: boolean;
 };
 
-/// Status of a transaction in the in-session history.
-/// - `pending`:  user is being prompted to sign
-/// - `sent`:     the wallet returned a hash, waiting for the receipt
-/// - `mined`:    the receipt has been retrieved
-/// - `failed`:   the wallet rejected, the send failed, or the receipt fetch failed
+// Status of a transaction in the in-session history.
+// - `pending`:  user is being prompted to sign
+// - `sent`:     the wallet returned a hash, waiting for the receipt
+// - `mined`:    the receipt has been retrieved
+// - `failed`:   the wallet rejected, the send failed, or the receipt fetch failed
 export type TxStatus = "pending" | "sent" | "mined" | "failed";
 
-/// Status of a signing request in the in-session history.
-/// - `pending`: user is being prompted to sign
-/// - `signed`:  signature returned successfully
-/// - `failed`:  the wallet rejected or signing failed
+// Status of a signing request in the in-session history.
+// - `pending`: user is being prompted to sign
+// - `signed`:  signature returned successfully
+// - `failed`:  the wallet rejected or signing failed
 export type SignStatus = "pending" | "signed" | "failed";
 
 export type TxHistoryEntry = {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,4 +1,4 @@
-import type { TransactionRequest } from "viem";
+import type { Hex, TransactionReceipt, TransactionRequest } from "viem";
 
 declare global {
   interface Window {
@@ -12,9 +12,11 @@ declare global {
   }
 }
 
+export type SignType = "PersonalSign" | "SignTypedDataV4";
+
 export type PendingSigning = {
   id: string;
-  signType: "PersonalSign" | "SignTypedDataV4";
+  signType: SignType;
   request: {
     message: string;
     address: string;
@@ -59,3 +61,47 @@ export type ApiOk<T> = { status: "ok"; data: T };
 export type ApiErr = { status: string; message?: string };
 
 export type PendingAny = Record<string, unknown> & { id: string; request: TransactionRequest };
+
+/// Mirrors the `SessionInfo` type returned by `GET /api/session` from the
+/// Rust BrowserWalletServer.
+export type SessionInfo = {
+  alive: boolean;
+  connected: boolean;
+};
+
+/// Status of a transaction in the in-session history.
+/// - `pending`:  user is being prompted to sign
+/// - `sent`:     the wallet returned a hash, waiting for the receipt
+/// - `mined`:    the receipt has been retrieved
+/// - `failed`:   the wallet rejected, the send failed, or the receipt fetch failed
+export type TxStatus = "pending" | "sent" | "mined" | "failed";
+
+/// Status of a signing request in the in-session history.
+/// - `pending`: user is being prompted to sign
+/// - `signed`:  signature returned successfully
+/// - `failed`:  the wallet rejected or signing failed
+export type SignStatus = "pending" | "signed" | "failed";
+
+export type TxHistoryEntry = {
+  kind: "tx";
+  id: string;
+  ts: number;
+  request: Record<string, unknown>;
+  status: TxStatus;
+  hash?: Hex;
+  receipt?: TransactionReceipt;
+  error?: string;
+};
+
+export type SignHistoryEntry = {
+  kind: "sign";
+  id: string;
+  ts: number;
+  signType: SignType;
+  request: { message: string; address: string };
+  status: SignStatus;
+  signature?: Hex;
+  error?: string;
+};
+
+export type HistoryEntry = TxHistoryEntry | SignHistoryEntry;


### PR DESCRIPTION
## Summary
Keep one wallet connection alive across multiple requests and show a clean
in-session history, useful when running scripts.

Core logic:
- Combined tx+signing poller that re-arms as soon as the current
  request completes; no reload between requests.
- `/api/session` liveness poller surfaces a "session ended" badge
  when the script finishes or the server is gone.
- In-session `HistoryEntry[]` with status badges
  (tx: pending/sent/mined/failed; sign: pending/signed/failed).
- Receipt fetched in the background after the wallet returns a hash,
  so the next request is picked up immediately.
- Explicit **Disconnect** and **Reject** buttons

UI:

- Unified `.btn` system (`primary` / `secondary` / `danger`) shared
  by every session-level action.
- History rows clearly readable as dropdowns
- Full transaction hash shown in mined/sent summaries.

Closes #16
Closes #17

<img height="750" alt="image" src="https://github.com/user-attachments/assets/aca94088-43e8-4487-9ba7-5888d696eebd" />
