### PR TITLE
chore: add @mablr, @figtracer, @stevencartavia to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @zerosnacks
+* @zerosnacks @mablr @figtracer @stevencartavia


### PR DESCRIPTION
Adds @mablr, @figtracer, and @stevencartavia as code owners alongside @zerosnacks.