### PR TITLE
docs: deprecate repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Browser wallet
 
+> [!IMPORTANT]
+> This repository is deprecated. The browser wallet is now maintained as part of
+> [`foundry-wallets`](https://github.com/foundry-rs/foundry-core/tree/main/crates/wallets/src/wallet_browser/app/src).
+> Please open new issues and pull requests in
+> [`foundry-rs/foundry-core`](https://github.com/foundry-rs/foundry-core).
+
 Interface for interacting with Foundry from the browser.
 
 ### Development


### PR DESCRIPTION
## Summary

- Mark this repository as deprecated following the browser wallet migration in foundry-rs/foundry-core#116.
- Point contributors to the new source location and issue tracker in `foundry-rs/foundry-core`.

Merge after foundry-rs/foundry-core#116.
